### PR TITLE
Automate configuration regeneration and health-check logging with Python

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,11 @@
+{
+  "port": 3443,
+  "tls": {
+    "keyPath": "./certs/key.pem",
+    "certPath": "./certs/cert.pem"
+  },
+  "oauth": {
+    "clientID": "511753985974-ke70bv07ifkiaop93sq70da9pc0vairk.apps.googleusercontent.com",
+    "callbackURL": "<https://localhost:3443/auth/google/callback>"
+  }
+}

--- a/generated_params.json
+++ b/generated_params.json
@@ -1,0 +1,6 @@
+{
+  "serverPort": 3443,
+  "tlsKey": "/Users/josevega/Desktop/Programming/Projects/TicketFlow Express/certs/key.pem",
+  "tlsCert": "/Users/josevega/Desktop/Programming/Projects/TicketFlow Express/certs/cert.pem",
+  "oauthRedirect": "<https://localhost:3443/auth/google/callback>"
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "start": "node dist/server.js",
     "dev": "node --loader ts-node/esm server.ts",
     "build": "tsc",
-    "regen-params": "python3 scripts/regen_params.py"
+    "regen": "python3 scripts/regen_params.py",
+    "health": "python3 scripts/health_check.py",
+    "automation": "npm run regen && npm run health"
   },
   "type": "module",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node dist/server.js",
     "dev": "node --loader ts-node/esm server.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "regen-params": "python3 scripts/regen_params.py"
   },
   "type": "module",
   "keywords": [],

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -1,0 +1,32 @@
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+LOG_FILE = Path(__file__).parent.parent / "health.log" # Route to the health log file
+URL = "https://localhost:3443/" # URL to check
+
+def main():
+    # 1) Launch curl with --insecure to ignore self-signed
+    try:
+        result = subprocess.run( # Execute curl command
+            ["curl", "--insecure", "--silent", "--write-out", "%{http_code}", URL], # --silent to suppress progress meter
+            capture_output=True, # Capture output
+            text=True, # Return output as string
+            timeout=5 # Timeout after 5 seconds
+        )
+        status = result.stdout.strip()
+    except Exception as e:
+        status = f"ERROR: {e}"
+
+    # 2) Register timestamp and code in health.log
+    now = datetime.now().isoformat()
+    entry = f"{now} — {URL} returned {status}\n" # \n for new line
+    
+    # Append to the log instead of overwriting
+    with LOG_FILE.open('a', encoding="utf-8") as f:
+        f.write(entry) # Write the entry to the log file
+    
+    print(f"✅ Health-check logged: {entry.strip()}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regen_params.py
+++ b/scripts/regen_params.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+# Routes
+ROOT = Path(__file__).parent.parent # Route to the root of the project
+
+# Files
+CONFIG_IN = ROOT / "config.json" # Input configuration file
+PARAM_OUT = ROOT / "generated_params.json" # Output parameters file
+
+def main():
+    # 1) Read config.json
+    config = json.loads(CONFIG_IN.read_text(encoding="utf-8"))
+
+    # 2) Transform it into “parameters”
+    params = {
+        "serverPort": config["port"],
+        "tlsKey": str(ROOT / config["tls"]["keyPath"]),
+        "tlsCert": str(ROOT / config["tls"]["certPath"]),
+        "oauthRedirect": config["oauth"]["callbackURL"]
+    }
+
+    # 3) Write generated_params.json
+    PARAM_OUT.write_text(json.dumps(params, indent=2), encoding="utf-8")
+    print(f"✅ Parameters regenerated in {PARAM_OUT}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Automate configuration regeneration and health-check logging with Python

This pull request introduces a lightweight Python-based automation layer to our project, covering two core tasks:

## 1. `scripts/regen_params.py`
- Reads the existing `config.json` (port, TLS paths, OAuth callback URL)  
- Transforms and extracts those values into a new `generated_params.json` file  
- Ensures there’s a single source of truth for downstream processes  

## 2. `scripts/health_check.py`
- Performs an HTTPS health check against `https://localhost:3443/` using `curl --insecure`  
- Captures the HTTP status code (or error) alongside an ISO-formatted timestamp  
- Appends each result as a new line into `health.log`, creating a running history of service availability  

---

### Additional changes
- Added both scripts under a new `scripts/` directory  
- Updated `.gitignore` to exclude `health.log` and other `*.log` files  
- Enhanced `package.json` with npm scripts:  
  - `npm run regen` → regenerates `generated_params.json`  
  - `npm run health` → performs a single health check  
  - `npm run automation` → chains regen + health in one command  

With these additions, we now have a repeatable, version-controlled way to rebuild our runtime parameters and monitor service health automatically—laying the groundwork for further CI/CD integration.  
Please review and merge into `dev`.
